### PR TITLE
Adiciona tipos de arquivos não relacionados anteriormente no Makefile para opção clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ view:
 	evince $(name-of-the-file).pdf &
 
 clean:
-	rm *.aux *.dvi *.log *.ps *.toc *.bm
+	rm *.bbl *.bcf *.blg *.xml *.aux *.dvi *.log *.ps *.toc *.bm


### PR DESCRIPTION
Foram adicionados os tipos bbl, bcf, blg, e xml

Fix #6 